### PR TITLE
[Unity] add default auth header for the unity catalog python client

### DIFF
--- a/dbt/adapters/duckdb/plugins/unity.py
+++ b/dbt/adapters/duckdb/plugins/unity.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from enum import Enum
 from typing import Any
 from typing import Dict
@@ -240,22 +239,19 @@ class Plugin(BasePlugin):
         # Get the token from the UC secret
         token = uc_secret["token"]
 
+        # Get the optional base path from the plugin config
+        api_base_path = config.get("api_base_path", "api/2.1/unity-catalog")
+
         # Construct the full base URL
-        catalog_base_url = f"{host_and_port}/api/2.1/unity-catalog"
+        catalog_base_url = f"{host_and_port}/{api_base_path}"
 
         # Prism mocks the UC server to http://127.0.0.1:4010 with no option to specify a basePath (api/2.1/unity-catalog)
         # https://github.com/stoplightio/prism/discussions/906
         # This is why we need to check if we are running in pytest and only use the host_and_port
         # Otherwise we will not be able to connect to the mock UC server
-        if "pytest" in sys.modules:
-            self.uc_client: Unitycatalog = Unitycatalog(
-                base_url=host_and_port, default_headers={"Authorization": f"Bearer {token}"}
-            )
-        else:
-            # Otherwise, use the full base URL
-            self.uc_client: Unitycatalog = Unitycatalog(
-                base_url=catalog_base_url, default_headers={"Authorization": f"Bearer {token}"}
-            )
+        self.uc_client: Unitycatalog = Unitycatalog(
+            base_url=catalog_base_url, default_headers={"Authorization": f"Bearer {token}"}
+        )
 
     def load(self, source_config: SourceConfig):
         raise NotImplementedError("Loading data to Unitycatalog is not supported!")

--- a/dbt/adapters/duckdb/plugins/unity.py
+++ b/dbt/adapters/duckdb/plugins/unity.py
@@ -237,6 +237,9 @@ class Plugin(BasePlugin):
         # Get the endpoint from the UC secret
         host_and_port = uc_secret["endpoint"]
 
+        # Get the token from the UC secret
+        token = uc_secret["token"]
+
         # Construct the full base URL
         catalog_base_url = f"{host_and_port}/api/2.1/unity-catalog"
 
@@ -245,10 +248,14 @@ class Plugin(BasePlugin):
         # This is why we need to check if we are running in pytest and only use the host_and_port
         # Otherwise we will not be able to connect to the mock UC server
         if "pytest" in sys.modules:
-            self.uc_client: Unitycatalog = Unitycatalog(base_url=host_and_port)
+            self.uc_client: Unitycatalog = Unitycatalog(
+                base_url=host_and_port, default_headers={"Authorization": f"Bearer {token}"}
+            )
         else:
             # Otherwise, use the full base URL
-            self.uc_client: Unitycatalog = Unitycatalog(base_url=catalog_base_url)
+            self.uc_client: Unitycatalog = Unitycatalog(
+                base_url=catalog_base_url, default_headers={"Authorization": f"Bearer {token}"}
+            )
 
     def load(self, source_config: SourceConfig):
         raise NotImplementedError("Loading data to Unitycatalog is not supported!")

--- a/tests/functional/plugins/test_unity.py
+++ b/tests/functional/plugins/test_unity.py
@@ -58,7 +58,7 @@ class TestPlugins:
 
     @pytest.fixture(scope="class")
     def profiles_config_update(self, dbt_profile_target):
-        plugins = [{"module": "unity"}]
+        plugins = [{"module": "unity", "config": {"api_base_path": ""}}]
         extensions = dbt_profile_target.get("extensions")
         extensions.extend([{"name": "delta"}])
         return {


### PR DESCRIPTION
Adds a default auth header with a Databricks bearer token to authenticate when doing UC API requests